### PR TITLE
feat: add profile page for password updates and fix lint errors

### DIFF
--- a/client/app/[locale]/(auth)/profile/page.tsx
+++ b/client/app/[locale]/(auth)/profile/page.tsx
@@ -1,0 +1,36 @@
+import Profile from "@/app/components/Layout/authentication/Profile";
+
+export const metadata = {
+  title:
+    "Profil | Site Gîtes à Erce en Ariège - Modification du mot de passe",
+  description:
+    "Modifiez le mot de passe de votre compte en toute sécurité.",
+  openGraph: {
+    title:
+      "Profil - Site Gîtes à Erce en Ariège | Modification du mot de passe",
+    description:
+      "Accédez à la page de modification de mot de passe de votre compte sur le Site Gîtes.",
+    type: "website",
+    images: [
+      {
+        url: "/og/gites.jpg",
+        width: 1200,
+        height: 630,
+        alt: "Profil - Gîtes à Erce en Ariège",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title:
+      "Profil - Site Gîtes à Erce en Ariège | Modification du mot de passe",
+    description:
+      "Modifiez facilement et en toute sécurité le mot de passe de votre compte Site Gîtes.",
+  },
+};
+
+const ProfilePage = async () => {
+  return <Profile />;
+};
+
+export default ProfilePage;

--- a/client/app/components/Layout/AllBookings/BookingCard/index.tsx
+++ b/client/app/components/Layout/AllBookings/BookingCard/index.tsx
@@ -49,13 +49,6 @@ const BookingCard: React.FC<BookingCardProps> = ({
     emailTo: booking.email,
   };
 
-  const bookingStatusMsg =
-    booking.status === "pending"
-      ? "En attente"
-      : booking.status === "accepted"
-      ? "Acceptée"
-      : "Refusée";
-
   return (
     <Card className={classes["booking-card"]}>
       <div className={classes["booking-card__title"]}>

--- a/client/app/components/Layout/AllBookings/index.tsx
+++ b/client/app/components/Layout/AllBookings/index.tsx
@@ -74,7 +74,6 @@ const AllBookings: React.FC<{ bookings: Booking[] }> = ({ bookings }) => {
     status: bookingStatus,
     error: bookingError,
   } = useMyMutation({
-    queryKeys: ["bookings"],
     mutationFn: bookingDecisionRequest,
     onSuccessFn: (data) => {
       queryClient.setQueryData(["bookings"], (oldData: Booking[]) => {
@@ -90,7 +89,6 @@ const AllBookings: React.FC<{ bookings: Booking[] }> = ({ bookings }) => {
   });
 
   const { mutate: deleteBookingMutate } = useMyMutation({
-    queryKeys: ["bookings"],
     mutationFn: deleteBookingRequest,
     onSuccessFn: (data) => {
       queryClient.setQueryData(["bookings"], (oldData: Booking[]) => {

--- a/client/app/components/Layout/Booking/index.tsx
+++ b/client/app/components/Layout/Booking/index.tsx
@@ -193,7 +193,6 @@ const Booking: React.FC<BookingProps> = ({ shelterId }) => {
         icon: "error",
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     bookingStatus,
     resetNameHandler,

--- a/client/app/components/Layout/CropContent/lib/cropImage.ts
+++ b/client/app/components/Layout/CropContent/lib/cropImage.ts
@@ -38,7 +38,7 @@ export default async function getCroppedImg(
     canvas.height // destination height
   );
 
-  return new Promise<Blob | null>((resolve, _) => {
+  return new Promise<Blob | null>((resolve) => {
     // BLOB stands for a “Binary Large Object,” a data type that stores binary data.
     // Binary Large Objects (BLOBs) can be complex files like images or videos, unlike other data strings that only store letters and numbers.
     // A BLOB will hold multimedia objects to add to a database; however, not all databases support BLOB storage.

--- a/client/app/components/Layout/Gallery/index.tsx
+++ b/client/app/components/Layout/Gallery/index.tsx
@@ -59,7 +59,6 @@ const Gallery: React.FC<{
 
   const { isPending: sheltersIsPendingMutation, mutate: postPictureMutate } =
     useMyMutation({
-      queryKeys: ["sheltersWithPictures"],
       mutationFn: postPictureRequest,
       onSuccessFn: (newData) => {
         queryClient.invalidateQueries({ queryKey: ["shelters"] });
@@ -73,7 +72,6 @@ const Gallery: React.FC<{
 
   const { isPending: deletePictureIsPending, mutate: deletePictureMutate } =
     useMyMutation({
-      queryKeys: ["sheltersWithPictures"],
       mutationFn: deletePictureRequest,
       onSuccessFn: (newData) => {
         queryClient.invalidateQueries({ queryKey: ["shelters"] });
@@ -86,7 +84,6 @@ const Gallery: React.FC<{
     });
 
   const { mutate: mainPictureMutate } = useMyMutation({
-    queryKeys: ["sheltersWithPictures"],
     mutationFn: setMainPictureRequest,
     onMutate: async ({ shelterId, mainImgId }) => {
       await queryClient.cancelQueries({ queryKey: ["sheltersWithPictures"] });

--- a/client/app/components/Layout/Header/index.tsx
+++ b/client/app/components/Layout/Header/index.tsx
@@ -177,6 +177,20 @@ const Header: React.FC = () => {
               </li>
             )}
 
+            {isAuth && (
+              <li>
+                <Link
+                  href={`/${locale}/profile`}
+                  onClick={handleCloseMenu}
+                  className={`${classes.header__link} ${isActive(
+                    `/${locale}/profile`,
+                  )}`}
+                >
+                  {t("header.profile")}
+                </Link>
+              </li>
+            )}
+
             {showLogin && !isAuth && (
               <li>
                 <Link

--- a/client/app/components/Layout/Input/index.tsx
+++ b/client/app/components/Layout/Input/index.tsx
@@ -11,7 +11,6 @@ const Input: React.FC<InputOrTextareaProps> = ({
   icon,
   className,
   isVisible = true,
-  name,
   label,
   forgotPassword,
   onInputDateClick,

--- a/client/app/components/Layout/Rates/index.tsx
+++ b/client/app/components/Layout/Rates/index.tsx
@@ -62,7 +62,6 @@ const Rates: React.FC<RatesProps> = ({ shelterId }) => {
     status: putRatesStatus,
     error: putRatesError,
   } = useMyMutation({
-    queryKeys: ["rates", shelterId],
     mutationFn: (data: RatesPutRequestData) => ratesPutRequest(data),
     onSuccessFn: (data) => {
       queryClient.setQueryData(["rates", shelterId], (old: any) => {

--- a/client/app/components/Layout/ShelterItem/index.tsx
+++ b/client/app/components/Layout/ShelterItem/index.tsx
@@ -44,7 +44,6 @@ const SheltersItems: React.FC<SheltersItemsProps> = ({
     status: updateStatus,
     isPending,
   } = useMyMutation({
-    queryKeys: ["sheltersWithPictures"],
     mutationFn: updateShelterDescriptionRequest,
     onSuccessFn: (data) => {
       const prevData = queryClient.getQueryData<

--- a/client/app/components/Layout/authentication/Profile/index.tsx
+++ b/client/app/components/Layout/authentication/Profile/index.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import useInput from "../../../../hooks/use-input";
+import { useMyQuery, useMyMutation } from "../../../../hooks/use-query";
+import { useLocale, useTranslations } from "next-intl";
+
+import Card from "../../../UI/Card";
+import Input from "../../Input";
+import classes from "../style.module.css";
+import { getCSRF, updatePasswordRequest } from "../../../../lib/api";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+import useHTTPState from "../../../../hooks/use-http-state";
+import { useAppSelector } from "../../../../hooks/use-store";
+
+const Profile: React.FC = () => {
+  const t = useTranslations();
+  const router = useRouter();
+  const locale = useLocale();
+  const [isCurrentPasswordMasked, setIsCurrentPasswordMasked] = useState(true);
+  const [isNewPasswordMasked, setIsNewPasswordMasked] = useState(true);
+  const handleHTTPState = useHTTPState();
+  const isAuth = useAppSelector((state) => state.auth.isAuthentificated);
+
+  // Redirect if not authenticated
+  useEffect(() => {
+    if (!isAuth) {
+      router.replace(`/${locale}/login`);
+    }
+  }, [isAuth, router, locale]);
+
+  // Fetch CSRF token on mount
+  useMyQuery({
+    queryKey: ["getCSRF"],
+    queryFn: getCSRF,
+  });
+
+  // Current password input
+  const {
+    value: currentPasswordValue,
+    isValid: currentPasswordIsValid,
+    isTouched: currentPasswordIsTouched,
+    changeHandler: currentPasswordChangeHandler,
+    blurHandler: currentPasswordBlurHandler,
+    resetHandler: currentPasswordResetHandler,
+    passwordState: currentPasswordState,
+  } = useInput();
+
+  // New password input
+  const {
+    value: newPasswordValue,
+    isValid: newPasswordIsValid,
+    isTouched: newPasswordIsTouched,
+    changeHandler: newPasswordChangeHandler,
+    blurHandler: newPasswordBlurHandler,
+    resetHandler: newPasswordResetHandler,
+    passwordState: newPasswordState,
+  } = useInput();
+
+  const { mutate: updatePasswordMutate, status: updatePasswordStatus } =
+    useMyMutation({
+      mutationFn: updatePasswordRequest,
+      onErrorFn: (_err, errorMessage) => {
+        handleHTTPState("error", errorMessage || t("profile.error"));
+      },
+      onSuccessFn: () => {
+        handleHTTPState("success", t("profile.success"));
+        currentPasswordResetHandler();
+        newPasswordResetHandler();
+      },
+    });
+
+  useEffect(() => {
+    if (updatePasswordStatus === "pending") {
+      handleHTTPState("pending");
+    }
+  }, [updatePasswordStatus, handleHTTPState]);
+
+  const isFormValid = currentPasswordIsValid && newPasswordIsValid;
+
+  const submitHandler = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!isFormValid) return;
+
+    updatePasswordMutate({
+      actualPassword: currentPasswordValue,
+      newPassword: newPasswordValue,
+    });
+  };
+
+  // Don't render if not authenticated
+  if (!isAuth) {
+    return null;
+  }
+
+  return (
+    <Card className={classes.auth}>
+      <form onSubmit={submitHandler} className={classes["auth__form"]}>
+        <h3 className={classes["auth__title"]}>{t("profile.title")}</h3>
+        <div>
+          {/* Current Password */}
+          <Input
+            icon={
+              <FontAwesomeIcon
+                className={classes.form__icon}
+                onClick={() => setIsCurrentPasswordMasked((prev) => !prev)}
+                icon={isCurrentPasswordMasked ? faEyeSlash : faEye}
+              />
+            }
+            label={t("profile.currentPasswordLabel")}
+            isVisible={true}
+            className={
+              !currentPasswordIsValid && currentPasswordIsTouched
+                ? "form__input--red"
+                : ""
+            }
+            maxLength={32}
+            id="current-password"
+            onChange={currentPasswordChangeHandler}
+            onBlur={currentPasswordBlurHandler}
+            type={isCurrentPasswordMasked ? "password" : "text"}
+            value={currentPasswordValue}
+            placeholder={t("profile.currentPasswordPlaceholder")}
+          />
+          {currentPasswordState.length > 0 && (
+            <ul className={classes["auth__password-error-list"]}>
+              <span>{t("profile.passwordRequirements")}</span>
+              {currentPasswordState.map((item) => (
+                <li key={item.toString()}>{item}</li>
+              ))}
+            </ul>
+          )}
+
+          {/* New Password */}
+          <Input
+            icon={
+              <FontAwesomeIcon
+                className={classes.form__icon}
+                onClick={() => setIsNewPasswordMasked((prev) => !prev)}
+                icon={isNewPasswordMasked ? faEyeSlash : faEye}
+              />
+            }
+            label={t("profile.newPasswordLabel")}
+            isVisible={true}
+            className={
+              !newPasswordIsValid && newPasswordIsTouched
+                ? "form__input--red"
+                : ""
+            }
+            maxLength={32}
+            id="new-password"
+            onChange={newPasswordChangeHandler}
+            onBlur={newPasswordBlurHandler}
+            type={isNewPasswordMasked ? "password" : "text"}
+            value={newPasswordValue}
+            placeholder={t("profile.newPasswordPlaceholder")}
+          />
+          {newPasswordState.length > 0 && (
+            <ul className={classes["auth__password-error-list"]}>
+              <span>{t("profile.passwordRequirements")}</span>
+              {newPasswordState.map((item) => (
+                <li key={item.toString()}>{item}</li>
+              ))}
+            </ul>
+          )}
+
+          <button
+            disabled={!isFormValid}
+            className={`button ${classes["auth__button"]}`}
+          >
+            {t("common.save")}
+          </button>
+        </div>
+      </form>
+    </Card>
+  );
+};
+
+export default Profile;

--- a/client/app/global/module.d.ts
+++ b/client/app/global/module.d.ts
@@ -2,7 +2,7 @@ import { OverridableComponent } from "@mui/material/OverridableComponent";
 import { SvgIconTypeMap } from "@mui/material/SvgIcon";
 
 declare module "@mui/icons-material" {
-  type MuiIconType = OverridableComponent<SvgIconTypeMap<{}, "svg">> & {
+  type MuiIconType = OverridableComponent<SvgIconTypeMap<object, "svg">> & {
     muiName: string;
   };
 }

--- a/client/app/hooks/use-input.ts
+++ b/client/app/hooks/use-input.ts
@@ -58,8 +58,7 @@ const inputReducer = (state: InputState, action: InputAction): InputState => {
         }
         break;
       case "email":
-        // eslint-disable-next-line no-useless-escape
-        const mailformat = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/;
+        const mailformat = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
         if (actionValue.value.match(mailformat)) {
           return { ...state, isValid: true, enteredValue: actionValue.value };
         }

--- a/client/app/hooks/use-query.ts
+++ b/client/app/hooks/use-query.ts
@@ -96,13 +96,11 @@ export function useMyQueries<T extends readonly UseMyQueryType<any>[]>(
 // and TResponse to represent the type of data returned by the mutation function
 
 export function useMyMutation<TRequest = any, TResponse = any>({
-  queryKeys,
   mutationFn,
   onErrorFn,
   onSuccessFn,
   ...props
 }: {
-  queryKeys?: QueryKey;
   mutationFn: HTTPRequestType<TRequest, TResponse>;
   onErrorFn?: (error: any, errorMessage: string) => void;
   onSuccessFn?: (data: TResponse, vars: TRequest, context: any) => void;

--- a/client/app/lib/api.tsx
+++ b/client/app/lib/api.tsx
@@ -98,6 +98,21 @@ export const resetPasswordRequest = async (data: ResetPasswordRequestData) => {
   if (response.status !== 200) throw new Error();
 };
 
+// Update password (authenticated user)
+export interface UpdatePasswordRequestData {
+  actualPassword: string;
+  newPassword: string;
+}
+
+export const updatePasswordRequest = async (data: UpdatePasswordRequestData) => {
+  const response = await instance.patch(
+    "/authentification/update-password",
+    data
+  );
+
+  if (response.status !== 200) throw new Error();
+};
+
 // Logout
 export const logoutRequest = async () => {
   const response = await instance.get("/authentification/logout");

--- a/client/public/messages/en.json
+++ b/client/public/messages/en.json
@@ -68,6 +68,16 @@
     "error": "An error occurred.",
     "invalidLink": "Invalid reset link."
   },
+  "profile": {
+    "title": "Change Password",
+    "currentPasswordLabel": "Current Password",
+    "currentPasswordPlaceholder": "Enter your current password",
+    "newPasswordLabel": "New Password",
+    "newPasswordPlaceholder": "Enter your new password",
+    "passwordRequirements": "Password must contain:",
+    "success": "Password has been successfully updated.",
+    "error": "An error occurred while updating the password."
+  },
   "forgotPassword": {
     "title": "Password Reset",
     "description": "Request a password reset for your account.",
@@ -222,6 +232,7 @@
     "shelters": "Lodgings",
     "albums": "Albums",
     "requests": "Requests",
+    "profile": "Profile",
     "login": "Login",
     "logout": "Logout"
   },

--- a/client/public/messages/fr.json
+++ b/client/public/messages/fr.json
@@ -68,6 +68,16 @@
     "error": "Une erreur est survenue.",
     "invalidLink": "Lien de réinitialisation invalide."
   },
+  "profile": {
+    "title": "Modifier le mot de passe",
+    "currentPasswordLabel": "Mot de passe actuel",
+    "currentPasswordPlaceholder": "Entrez votre mot de passe actuel",
+    "newPasswordLabel": "Nouveau mot de passe",
+    "newPasswordPlaceholder": "Entrez votre nouveau mot de passe",
+    "passwordRequirements": "Le mot de passe doit comporter :",
+    "success": "Le mot de passe a été mis à jour avec succès.",
+    "error": "Une erreur est survenue lors de la mise à jour du mot de passe."
+  },
   "forgotPassword": {
     "title": "Réinitialisation Du Mot De Passe",
     "description": "Demandez la réinitialisation de votre mot de passe pour votre compte.",
@@ -222,6 +232,7 @@
     "shelters": "Gîtes",
     "albums": "Albums",
     "requests": "Demandes",
+    "profile": "Profil",
     "login": "Connexion",
     "logout": "Déconnexion"
   },

--- a/server/app/controllers/authController.ts
+++ b/server/app/controllers/authController.ts
@@ -2,6 +2,7 @@ import debugLib from "debug";
 import { Request, Response, NextFunction, CookieOptions } from "express";
 import jwt from "jsonwebtoken";
 import path from "path";
+import bcrypt from "bcrypt";
 import { User } from "../models";
 import ExpressError from "../utilities/ExpressError";
 import axios from "axios";
@@ -229,6 +230,37 @@ const authController = {
     if (isPasswordUpdated) {
       res.sendStatus(200);
     } else next();
+  },
+
+  async updatePassword(req: Request, res: Response) {
+    const { actualPassword, newPassword } = req.body;
+
+    // Get user info from token (set by checkAuthenticated middleware)
+    const userPayload = (req as any).user;
+
+    if (!userPayload?.username) {
+      return res.sendStatus(401);
+    }
+
+    // Find user by username from token
+    const user = await User.findOne({ username: userPayload.username });
+
+    if (!user) {
+      return res.sendStatus(401);
+    }
+
+    // Verify current password
+    const isValidPassword = await bcrypt.compare(actualPassword, user.password);
+
+    if (!isValidPassword) {
+      return res.sendStatus(401);
+    }
+
+    // Hash and update new password
+    const hashedPassword = await User.hashPassword(newPassword);
+    await User.findByIdAndUpdate(user._id, { password: hashedPassword });
+
+    res.sendStatus(200);
   },
 };
 

--- a/server/app/middlewares.ts
+++ b/server/app/middlewares.ts
@@ -13,7 +13,7 @@ export const csrfProtection = csurf({
   cookie: csrfCookieConfig,
 });
 
-// Vérifie que l'utilisateur est connecté
+// Vérifie que l'utilisateur est connecté (admin uniquement)
 export const checkLogged = (
   req: Request,
   res: Response,
@@ -38,6 +38,29 @@ export const checkLogged = (
 
       if (!isAdmin) return res.sendStatus(403);
 
+      next();
+    }
+  );
+};
+
+// Vérifie que l'utilisateur est authentifié (tout utilisateur connecté)
+export const checkAuthenticated = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const token = req.cookies?.accessToken;
+
+  if (!token) return res.sendStatus(401);
+
+  jwt.verify(
+    token,
+    process.env.ACCESS_TOKEN_SECRET as string,
+    (err: any, decoded: any) => {
+      if (err || !decoded) return res.sendStatus(401);
+
+      // Attach user info to request for use in controller
+      (req as any).user = decoded;
       next();
     }
   );

--- a/server/app/router/authRouter.ts
+++ b/server/app/router/authRouter.ts
@@ -7,9 +7,10 @@ import {
   passwordSchema,
   emailSchema,
   confirmEmailSchema,
+  updatePasswordSchema,
 } from "../validation/schemas";
 import catchAsync from "../utilities/catchAsync";
-import { csrfProtection } from "../middlewares";
+import { csrfProtection, checkAuthenticated } from "../middlewares";
 
 const router = express.Router();
 
@@ -39,6 +40,13 @@ router.patch(
   csrfProtection,
   validate(passwordSchema),
   catchAsync(authController.resetPassword)
+);
+router.patch(
+  "/update-password",
+  csrfProtection,
+  checkAuthenticated,
+  validate(updatePasswordSchema),
+  catchAsync(authController.updatePassword)
 );
 
 export default router;

--- a/server/app/validation/schemas.js
+++ b/server/app/validation/schemas.js
@@ -202,6 +202,32 @@ module.exports.passwordSchema = joi
   .required();
 
 /**
+ * updatePasswordSchema monitor the update password request body, and return an error if any of requirements doesn't match with it
+ */
+module.exports.updatePasswordSchema = joi
+  .object({
+    actualPassword: joiPassword
+      .string()
+      .minOfLowercase(1)
+      .minOfUppercase(1)
+      .minOfNumeric(1)
+      .minOfSpecialCharacters(1)
+      .noWhiteSpaces()
+      .min(8)
+      .required(),
+    newPassword: joiPassword
+      .string()
+      .minOfLowercase(1)
+      .minOfUppercase(1)
+      .minOfNumeric(1)
+      .minOfSpecialCharacters(1)
+      .noWhiteSpaces()
+      .min(8)
+      .required(),
+  })
+  .required();
+
+/**
  * postBookingSchema monitor the post booking request body, and return an error if any of requirements doesn't match with it
  */
 module.exports.postBookingSchema = joi


### PR DESCRIPTION
- Add Profile page where authenticated users can update their password
- Require current password verification before allowing password change
- Add checkAuthenticated middleware for non-admin auth routes
- Add updatePassword controller, route, and validation schema
- Add Profile link in header navigation (visible when logged in)
- Add French and English translations for profile page

Also fixes TypeScript/ESLint errors:
- Replace empty object type {} with object in module.d.ts
- Remove unused variables and eslint-disable directives
- Remove unused queryKeys parameter from useMyMutation